### PR TITLE
Setting twitter vars in env instead of files

### DIFF
--- a/source/plugins/twitter/index.php
+++ b/source/plugins/twitter/index.php
@@ -1,10 +1,10 @@
 <?php
 
-require('tmi-twitter-config.inc');
-
 /**
  * Retrieves the access token needed for making API calls using Twitter's
  * application-only authentication.
+ * Requires setting 'TMITWEETS_CONSUMER_SECRET' and 'TMITWEETS_CONSUMER_KEY'
+ * env vars
  */
 
 class TmiTwitterOauth2 {


### PR DESCRIPTION
The auth vars for twitter should be set in env vars instead of a file.